### PR TITLE
new api commit_i for pedersen commitment of int64 value

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -494,6 +494,17 @@ extern "C" {
     ) -> c_int;
 
     // Generates a pedersen commitment: *commit = blind * G + value * G2.
+    // Same as secp256k1_pedersen_commit() except with i64 value instead of u64.
+    pub fn secp256k1_pedersen_commit_i(
+        ctx: *const Context,
+        commit: *mut c_uchar,
+        blind: *const c_uchar,
+        value: i64,
+        value_gen: *const c_uchar,
+        blind_gen: *const c_uchar
+    ) -> c_int;
+
+    // Generates a pedersen commitment: *commit = blind * G + value * G2.
     // The commitment is 33 bytes, the blinding factor and the value are 32 bytes.
     pub fn secp256k1_pedersen_blind_commit(
         ctx: *const Context,

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -380,6 +380,7 @@ impl Secp256k1 {
     }
 
     /// Creates a pedersen commitment from a value and a blinding factor
+    /// Same as commit() except with i64 value instead of u64.
     pub fn commit_i(&self, value: i64, blind: SecretKey) -> Result<Commitment, Error> {
         if self.caps != ContextFlag::Commit {
             return Err(Error::IncapableContext);


### PR DESCRIPTION
To support the public value transaction of Gotts, add a new API to create Pedersen Commitment with `i64` value which can be either `>=0` or `<0`.


```Rust
    /// Creates a pedersen commitment from a value and a blinding factor
    /// Same as commit() except with i64 value instead of u64.
    pub fn commit_i(&self, value: i64, blind: SecretKey) -> Result<Commitment, Error>
```