### PR TITLE
Use the simple secp256k1 context object with no precomputed tables

### DIFF
--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -34,7 +34,7 @@ pub const ZERO_256: [u8; 32] = [0u8; 32];
 /// msg: the message to sign
 /// seckey: the secret key
 pub fn export_secnonce_single(secp: &Secp256k1) -> Result<SecretKey, Error> {
-    let mut return_key = SecretKey::new(&secp, &mut thread_rng());
+    let mut return_key = SecretKey::new(&mut thread_rng());
     let mut seed = [0u8; 32];
     thread_rng().fill(&mut seed);
     let retval = unsafe {
@@ -475,7 +475,7 @@ mod tests {
         thread_rng().fill(&mut msg);
         let msg = Message::from_slice(&msg).unwrap();
         let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
-        let der = sig.serialize_der(&secp);
+        let der = sig.serialize_der();
         println!(
             "schnorr signature len: {}, der: {}",
             der.len(),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -503,7 +503,7 @@ extern "C" {
         blind: *const c_uchar,
         value: i64,
         value_gen: *const c_uchar,
-        blind_gen: *const c_uchar
+        blind_gen: *const c_uchar,
     ) -> c_int;
 
     // Generates a pedersen commitment: *commit = blind * G + value * G2.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -190,6 +190,8 @@ extern "C" {
     #[allow(dead_code)]
     pub static secp256k1_nonce_function_default: NonceFn;
 
+    pub static secp256k1_context_no_precomp: *const Context;
+
     // Contexts
     pub fn secp256k1_context_create(flags: c_uint) -> *mut Context;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -58,10 +58,10 @@ fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {
 impl SecretKey {
     /// Creates a new random secret key
     #[inline]
-    pub fn new<R: Rng>(secp: &Secp256k1, rng: &mut R) -> SecretKey {
+    pub fn new<R: Rng>(rng: &mut R) -> SecretKey {
         let mut data = random_32_bytes(rng);
         unsafe {
-            while ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
+            while ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
                 data = random_32_bytes(rng);
             }
         }
@@ -70,12 +70,12 @@ impl SecretKey {
 
     /// Converts a `SECRET_KEY_SIZE`-byte slice to a secret key
     #[inline]
-    pub fn from_slice(secp: &Secp256k1, data: &[u8]) -> Result<SecretKey, Error> {
+    pub fn from_slice(data: &[u8]) -> Result<SecretKey, Error> {
         match data.len() {
             constants::SECRET_KEY_SIZE => {
                 let mut ret = [0; constants::SECRET_KEY_SIZE];
                 unsafe {
-                    if ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
+                    if ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
                         return Err(InvalidSecretKey);
                     }
                 }
@@ -88,9 +88,9 @@ impl SecretKey {
 
     #[inline]
     /// Adds one secret key to another, modulo the curve order
-    pub fn add_assign(&mut self, secp: &Secp256k1, other: &SecretKey) -> Result<(), Error> {
+    pub fn add_assign(&mut self, other: &SecretKey) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_add(secp.ctx, self.as_mut_ptr(), other.as_ptr()) != 1
+            if ffi::secp256k1_ec_privkey_tweak_add(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1
             {
                 Err(InvalidSecretKey)
             } else {
@@ -101,9 +101,9 @@ impl SecretKey {
 
     #[inline]
     /// Multiplies one secret key by another, modulo the curve order
-    pub fn mul_assign(&mut self, secp: &Secp256k1, other: &SecretKey) -> Result<(), Error> {
+    pub fn mul_assign(&mut self, other: &SecretKey) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_mul(secp.ctx, self.as_mut_ptr(), other.as_ptr()) != 1
+            if ffi::secp256k1_ec_privkey_tweak_mul(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1
             {
                 Err(InvalidSecretKey)
             } else {
@@ -114,9 +114,9 @@ impl SecretKey {
 
     #[inline]
     /// Inverses the secret key
-    pub fn inv_assign(&mut self, secp: &Secp256k1) -> Result<(), Error> {
+    pub fn inv_assign(&mut self) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_inv(secp.ctx, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_inv(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -126,9 +126,9 @@ impl SecretKey {
 
     #[inline]
     /// Negates the secret key
-    pub fn neg_assign(&mut self, secp: &Secp256k1) -> Result<(), Error> {
+    pub fn neg_assign(&mut self) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_neg(secp.ctx, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_neg(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -146,17 +146,13 @@ impl PublicKey {
 
     /// Creates a new public key as the sum of the provided keys
     pub fn from_combination(
-        secp: &Secp256k1,
         in_keys: Vec<&PublicKey>,
     ) -> Result<PublicKey, Error> {
         let mut retkey = PublicKey::new();
-        if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
-            return Err(IncapableContext);
-        }
         let in_vec: Vec<*const ffi::PublicKey> = in_keys.iter().map(|pk| pk.as_ptr()).collect();
         unsafe {
             if ffi::secp256k1_ec_pubkey_combine(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut retkey.0 as *mut _,
                 in_vec.as_ptr(),
                 in_vec.len() as i32,
@@ -213,11 +209,11 @@ impl PublicKey {
 
     /// Creates a public key directly from a slice
     #[inline]
-    pub fn from_slice(secp: &Secp256k1, data: &[u8]) -> Result<PublicKey, Error> {
+    pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
         let mut pk = unsafe { ffi::PublicKey::blank() };
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut pk,
                 data.as_ptr(),
                 data.len() as ::libc::size_t,
@@ -234,7 +230,7 @@ impl PublicKey {
     /// Serialize the key as a byte-encoded pair of values. In compressed form
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
-    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) -> Vec<u8> {
+    pub fn serialize_vec(&self, compressed: bool) -> Vec<u8> {
         // This must be 72 for compatibility with the `ArrayVec` library.
         let mut ret = ArrayVec::<[u8; 72]>::new();
 
@@ -246,7 +242,7 @@ impl PublicKey {
                 ffi::SECP256K1_SER_UNCOMPRESSED
             };
             let err = ffi::secp256k1_ec_pubkey_serialize(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 ret.as_ptr(),
                 &mut ret_len,
                 self.as_ptr(),
@@ -320,13 +316,11 @@ mod test {
     // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.
     #[test]
     fn skey_clear_on_drop() {
-        let s = Secp256k1::new();
-
         // Create buffer for blinding factor filled with non-zero bytes.
         let sk_bytes = ONE_KEY;
         let ptr = {
             // Fill blinding factor with some "sensitive" data.
-            let sk = SecretKey::from_slice(&s, &sk_bytes[..]).unwrap();
+            let sk = SecretKey::from_slice(&sk_bytes[..]).unwrap();
             sk.0.as_ptr()
 
             // -- after this line SecretKey should be zeroed.
@@ -348,22 +342,19 @@ mod test {
 
     #[test]
     fn skey_from_slice() {
-        let s = Secp256k1::new();
-        let sk = SecretKey::from_slice(&s, &[1; 31]);
+        let sk = SecretKey::from_slice(&[1; 31]);
         assert_eq!(sk, Err(InvalidSecretKey));
 
-        let sk = SecretKey::from_slice(&s, &[1; 32]);
+        let sk = SecretKey::from_slice(&[1; 32]);
         assert!(sk.is_ok());
     }
 
     #[test]
     fn pubkey_from_slice() {
-        let s = Secp256k1::new();
-        assert_eq!(PublicKey::from_slice(&s, &[]), Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[1, 2, 3]), Err(InvalidPublicKey));
+        assert_eq!(PublicKey::from_slice(&[]), Err(InvalidPublicKey));
+        assert_eq!(PublicKey::from_slice(&[1, 2, 3]), Err(InvalidPublicKey));
 
         let uncompressed = PublicKey::from_slice(
-            &s,
             &[
                 4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224,
                 85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53,
@@ -374,7 +365,6 @@ mod test {
         assert!(uncompressed.is_ok());
 
         let compressed = PublicKey::from_slice(
-            &s,
             &[
                 3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51,
                 41, 111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78,
@@ -388,30 +378,28 @@ mod test {
         let s = Secp256k1::new();
 
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        assert_eq!(SecretKey::from_slice(&s, &sk1[..]), Ok(sk1));
+        assert_eq!(SecretKey::from_slice(&sk1[..]), Ok(sk1));
         assert_eq!(
-            PublicKey::from_slice(&s, &pk1.serialize_vec(&s, true)[..]),
+            PublicKey::from_slice(&pk1.serialize_vec(true)[..]),
             Ok(pk1)
         );
         assert_eq!(
-            PublicKey::from_slice(&s, &pk1.serialize_vec(&s, false)[..]),
+            PublicKey::from_slice(&pk1.serialize_vec(false)[..]),
             Ok(pk1)
         );
     }
 
     #[test]
     fn invalid_secret_key() {
-        let s = Secp256k1::new();
         // Zero
-        assert_eq!(SecretKey::from_slice(&s, &[0; 32]), Err(InvalidSecretKey));
+        assert_eq!(SecretKey::from_slice(&[0; 32]), Err(InvalidSecretKey));
         // -1
         assert_eq!(
-            SecretKey::from_slice(&s, &[0xff; 32]),
+            SecretKey::from_slice(&[0xff; 32]),
             Err(InvalidSecretKey)
         );
         // Top of range
         assert!(SecretKey::from_slice(
-            &s,
             &[
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                 0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
@@ -421,7 +409,6 @@ mod test {
         .is_ok());
         // One past top of range
         assert!(SecretKey::from_slice(
-            &s,
             &[
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                 0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
@@ -434,7 +421,7 @@ mod test {
     #[test]
     fn test_pubkey_from_slice_bad_context() {
         let s = Secp256k1::without_caps();
-        let sk = SecretKey::new(&s, &mut thread_rng());
+        let sk = SecretKey::new(&mut thread_rng());
         assert_eq!(PublicKey::from_secret_key(&s, &sk), Err(IncapableContext));
 
         let s = Secp256k1::with_caps(ContextFlag::VerifyOnly);
@@ -566,32 +553,31 @@ mod test {
 
     #[test]
     fn test_pubkey_from_bad_slice() {
-        let s = Secp256k1::new();
         // Bad sizes
         assert_eq!(
-            PublicKey::from_slice(&s, &[0; constants::COMPRESSED_PUBLIC_KEY_SIZE - 1]),
+            PublicKey::from_slice(&[0; constants::COMPRESSED_PUBLIC_KEY_SIZE - 1]),
             Err(InvalidPublicKey)
         );
         assert_eq!(
-            PublicKey::from_slice(&s, &[0; constants::COMPRESSED_PUBLIC_KEY_SIZE + 1]),
+            PublicKey::from_slice(&[0; constants::COMPRESSED_PUBLIC_KEY_SIZE + 1]),
             Err(InvalidPublicKey)
         );
         assert_eq!(
-            PublicKey::from_slice(&s, &[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE - 1]),
+            PublicKey::from_slice(&[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE - 1]),
             Err(InvalidPublicKey)
         );
         assert_eq!(
-            PublicKey::from_slice(&s, &[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE + 1]),
+            PublicKey::from_slice(&[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE + 1]),
             Err(InvalidPublicKey)
         );
 
         // Bad parse
         assert_eq!(
-            PublicKey::from_slice(&s, &[0xff; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE]),
+            PublicKey::from_slice(&[0xff; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE]),
             Err(InvalidPublicKey)
         );
         assert_eq!(
-            PublicKey::from_slice(&s, &[0x55; constants::COMPRESSED_PUBLIC_KEY_SIZE]),
+            PublicKey::from_slice(&[0x55; constants::COMPRESSED_PUBLIC_KEY_SIZE]),
             Err(InvalidPublicKey)
         );
     }
@@ -646,7 +632,7 @@ mod test {
         let s = Secp256k1::new();
         let (_, pk1) = s.generate_keypair(&mut DumbRng(0)).unwrap();
         assert_eq!(
-            &pk1.serialize_vec(&s, false)[..],
+            &pk1.serialize_vec(false)[..],
             &[
                 4, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126,
                 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229, 185, 28, 165,
@@ -655,7 +641,7 @@ mod test {
             ][..]
         );
         assert_eq!(
-            &pk1.serialize_vec(&s, true)[..],
+            &pk1.serialize_vec(true)[..],
             &[
                 3, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126,
                 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229
@@ -671,12 +657,12 @@ mod test {
         let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
-        assert!(sk1.add_assign(&s, &sk2).is_ok());
+        assert!(sk1.add_assign(&sk2).is_ok());
         assert!(pk1.add_exp_assign(&s, &sk2).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
-        assert!(sk2.add_assign(&s, &sk1).is_ok());
+        assert!(sk2.add_assign(&sk1).is_ok());
         assert!(pk2.add_exp_assign(&s, &sk1).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
     }
@@ -689,12 +675,12 @@ mod test {
         let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
-        assert!(sk1.mul_assign(&s, &sk2).is_ok());
+        assert!(sk1.mul_assign(&sk2).is_ok());
         assert!(pk1.mul_assign(&s, &sk2).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
-        assert!(sk2.mul_assign(&s, &sk1).is_ok());
+        assert!(sk2.mul_assign(&sk1).is_ok());
         assert!(pk2.mul_assign(&s, &sk1).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
     }
@@ -706,7 +692,7 @@ mod test {
         let (sk1, mut pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
         let (sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
-        let combined_pk = PublicKey::from_combination(&s, vec![&pk1, &pk2]).unwrap();
+        let combined_pk = PublicKey::from_combination(vec![&pk1, &pk2]).unwrap();
 
         let _ = pk2.add_exp_assign(&s, &sk1);
         let _ = pk1.add_exp_assign(&s, &sk2);
@@ -719,7 +705,6 @@ mod test {
         let s = Secp256k1::new();
 
         let one = SecretKey::from_slice(
-            &s,
             &[
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -729,19 +714,19 @@ mod test {
         .unwrap();
 
         let mut one_inv: SecretKey = one.clone();
-        one_inv.inv_assign(&s).unwrap();
+        one_inv.inv_assign().unwrap();
         assert_eq!(one_inv, one);
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.inv_assign(&s).unwrap();
-        sk2.inv_assign(&s).unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.inv_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.inv_assign(&s).unwrap();
-        sk2.mul_assign(&s, &sk1).unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.mul_assign(&sk1).unwrap();
         assert_eq!(sk2, one);
     }
 
@@ -751,27 +736,26 @@ mod test {
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.neg_assign(&s).unwrap();
-        assert!(sk2.add_assign(&s, &sk1).is_err());
+        sk2.neg_assign().unwrap();
+        assert!(sk2.add_assign(&sk1).is_err());
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.neg_assign(&s).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk2.neg_assign().unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk1.neg_assign(&s).unwrap();
+        sk1.neg_assign().unwrap();
         let sk1_clone = sk1.clone();
-        sk1.add_assign(&s, &sk1_clone).unwrap();
+        sk1.add_assign(&sk1_clone).unwrap();
         let sk2_clone = sk2.clone();
-        sk2.add_assign(&s, &sk2_clone).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk2.add_assign(&sk2_clone).unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let one = SecretKey::from_slice(
-            &s,
             &[
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -782,17 +766,17 @@ mod test {
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = one.clone();
-        sk2.neg_assign(&s).unwrap();
-        sk2.mul_assign(&s, &sk1).unwrap();
-        sk1.neg_assign(&s).unwrap();
+        sk2.neg_assign().unwrap();
+        sk2.mul_assign(&sk1).unwrap();
+        sk1.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk1.neg_assign(&s).unwrap();
-        sk1.inv_assign(&s).unwrap();
-        sk2.inv_assign(&s).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk1.neg_assign().unwrap();
+        sk1.inv_assign().unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -61,7 +61,9 @@ impl SecretKey {
     pub fn new<R: Rng>(rng: &mut R) -> SecretKey {
         let mut data = random_32_bytes(rng);
         unsafe {
-            while ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
+            while ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr())
+                == 0
+            {
                 data = random_32_bytes(rng);
             }
         }
@@ -75,7 +77,11 @@ impl SecretKey {
             constants::SECRET_KEY_SIZE => {
                 let mut ret = [0; constants::SECRET_KEY_SIZE];
                 unsafe {
-                    if ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
+                    if ffi::secp256k1_ec_seckey_verify(
+                        ffi::secp256k1_context_no_precomp,
+                        data.as_ptr(),
+                    ) == 0
+                    {
                         return Err(InvalidSecretKey);
                     }
                 }
@@ -90,7 +96,11 @@ impl SecretKey {
     /// Adds one secret key to another, modulo the curve order
     pub fn add_assign(&mut self, other: &SecretKey) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_add(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1
+            if ffi::secp256k1_ec_privkey_tweak_add(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_ptr(),
+                other.as_ptr(),
+            ) != 1
             {
                 Err(InvalidSecretKey)
             } else {
@@ -103,7 +113,11 @@ impl SecretKey {
     /// Multiplies one secret key by another, modulo the curve order
     pub fn mul_assign(&mut self, other: &SecretKey) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_mul(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1
+            if ffi::secp256k1_ec_privkey_tweak_mul(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_ptr(),
+                other.as_ptr(),
+            ) != 1
             {
                 Err(InvalidSecretKey)
             } else {
@@ -116,7 +130,11 @@ impl SecretKey {
     /// Inverses the secret key
     pub fn inv_assign(&mut self) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_inv(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_inv(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_ptr(),
+            ) != 1
+            {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -128,7 +146,11 @@ impl SecretKey {
     /// Negates the secret key
     pub fn neg_assign(&mut self) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_neg(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_neg(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_ptr(),
+            ) != 1
+            {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -145,9 +167,7 @@ impl PublicKey {
     }
 
     /// Creates a new public key as the sum of the provided keys
-    pub fn from_combination(
-        in_keys: Vec<&PublicKey>,
-    ) -> Result<PublicKey, Error> {
+    pub fn from_combination(in_keys: Vec<&PublicKey>) -> Result<PublicKey, Error> {
         let mut retkey = PublicKey::new();
         let in_vec: Vec<*const ffi::PublicKey> = in_keys.iter().map(|pk| pk.as_ptr()).collect();
         unsafe {
@@ -354,22 +374,18 @@ mod test {
         assert_eq!(PublicKey::from_slice(&[]), Err(InvalidPublicKey));
         assert_eq!(PublicKey::from_slice(&[1, 2, 3]), Err(InvalidPublicKey));
 
-        let uncompressed = PublicKey::from_slice(
-            &[
-                4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224,
-                85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53,
-                162, 124, 149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227,
-                183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188,
-            ],
-        );
+        let uncompressed = PublicKey::from_slice(&[
+            4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85,
+            220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124,
+            149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195,
+            155, 51, 247, 123, 113, 60, 228, 188,
+        ]);
         assert!(uncompressed.is_ok());
 
-        let compressed = PublicKey::from_slice(
-            &[
-                3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51,
-                41, 111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78,
-            ],
-        );
+        let compressed = PublicKey::from_slice(&[
+            3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41,
+            111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78,
+        ]);
         assert!(compressed.is_ok());
     }
 
@@ -379,10 +395,7 @@ mod test {
 
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
         assert_eq!(SecretKey::from_slice(&sk1[..]), Ok(sk1));
-        assert_eq!(
-            PublicKey::from_slice(&pk1.serialize_vec(true)[..]),
-            Ok(pk1)
-        );
+        assert_eq!(PublicKey::from_slice(&pk1.serialize_vec(true)[..]), Ok(pk1));
         assert_eq!(
             PublicKey::from_slice(&pk1.serialize_vec(false)[..]),
             Ok(pk1)
@@ -394,27 +407,20 @@ mod test {
         // Zero
         assert_eq!(SecretKey::from_slice(&[0; 32]), Err(InvalidSecretKey));
         // -1
-        assert_eq!(
-            SecretKey::from_slice(&[0xff; 32]),
-            Err(InvalidSecretKey)
-        );
+        assert_eq!(SecretKey::from_slice(&[0xff; 32]), Err(InvalidSecretKey));
         // Top of range
-        assert!(SecretKey::from_slice(
-            &[
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
-                0xD0, 0x36, 0x41, 0x40
-            ]
-        )
+        assert!(SecretKey::from_slice(&[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
+            0xD0, 0x36, 0x41, 0x40
+        ])
         .is_ok());
         // One past top of range
-        assert!(SecretKey::from_slice(
-            &[
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
-                0xD0, 0x36, 0x41, 0x41
-            ]
-        )
+        assert!(SecretKey::from_slice(&[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
+            0xD0, 0x36, 0x41, 0x41
+        ])
         .is_err());
     }
 
@@ -704,13 +710,11 @@ mod test {
     fn test_inverse() {
         let s = Secp256k1::new();
 
-        let one = SecretKey::from_slice(
-            &[
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x01,
-            ],
-        )
+        let one = SecretKey::from_slice(&[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01,
+        ])
         .unwrap();
 
         let mut one_inv: SecretKey = one.clone();
@@ -755,13 +759,11 @@ mod test {
         sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
-        let one = SecretKey::from_slice(
-            &[
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x01,
-            ],
-        )
+        let one = SecretKey::from_slice(&[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01,
+        ])
         .unwrap();
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,7 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
-
 extern crate serde_json as json;
-#[macro_use]
-extern crate lazy_static;
 
 #[macro_use]
 mod macros;
@@ -74,16 +71,3 @@ pub use types::{
     AggSigPartialSignature, ContextFlag, Error, Message, RecoverableSignature, RecoveryId,
     Secp256k1, Signature,
 };
-
-use std::sync::Arc;
-
-lazy_static! {
-    /// Static reference to a fake secp instance
-    static ref SECP256K1:Arc<types::Secp256k1>
-        = Arc::new(types::Secp256k1::with_caps(types::ContextFlag::Commit));
-}
-
-/// Returns a static fake secp instance, ONLY for those fake/not-used ctx usage
-fn static_secp_instance() -> Arc<types::Secp256k1> {
-    SECP256K1.clone()
-}

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -1176,7 +1176,10 @@ mod tests {
 
         assert!(secp.verify_commit_sum(vec![commit_i(-5)], vec![commit_i(-5)],));
         assert!(secp.verify_commit_sum(vec![commit_i(-3), commit_i(-2)], vec![commit_i(-5)]));
-        assert!(secp.verify_commit_sum(vec![commit_i(-2), commit_i(8)], vec![commit_i(-1), commit_i(7)]));
+        assert!(secp.verify_commit_sum(
+            vec![commit_i(-2), commit_i(8)],
+            vec![commit_i(-1), commit_i(7)]
+        ));
     }
 
     #[test]
@@ -1265,7 +1268,6 @@ mod tests {
             vec![commit_i(101, blind_pos)],
             vec![commit_i(127, blind_neg), commit_i(-26, blind_sum)],
         ));
-
     }
 
     #[test]
@@ -1281,7 +1283,7 @@ mod tests {
         let neg_value = 75;
 
         let blind_pos = secp
-            .blind_switch(pos_value, SecretKey::new( &mut thread_rng()))
+            .blind_switch(pos_value, SecretKey::new(&mut thread_rng()))
             .unwrap();
         let blind_neg = secp
             .blind_switch(neg_value, SecretKey::new(&mut thread_rng()))

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -509,7 +509,7 @@ impl Secp256k1 {
             );
         }
         // secp256k1 should never return an invalid private
-        SecretKey::from_slice(self, &ret)
+        SecretKey::from_slice(&ret)
     }
 
     /// Compute a blinding factor using a switch commitment
@@ -532,7 +532,7 @@ impl Secp256k1 {
                 1
             )
         }
-        SecretKey::from_slice(self, &ret)
+        SecretKey::from_slice(&ret)
     }
 
     /// Convenience function for generating a random nonce for a range proof.
@@ -1241,8 +1241,8 @@ mod tests {
             secp.commit(value, blinding).unwrap()
         }
 
-        let blind_pos = SecretKey::new(&secp, &mut thread_rng());
-        let blind_neg = SecretKey::new(&secp, &mut thread_rng());
+        let blind_pos = SecretKey::new(&mut thread_rng());
+        let blind_neg = SecretKey::new(&mut thread_rng());
 
         // now construct blinding factor to net out appropriately
         let blind_sum = secp
@@ -1281,10 +1281,10 @@ mod tests {
         let neg_value = 75;
 
         let blind_pos = secp
-            .blind_switch(pos_value, SecretKey::new(&secp, &mut thread_rng()))
+            .blind_switch(pos_value, SecretKey::new( &mut thread_rng()))
             .unwrap();
         let blind_neg = secp
-            .blind_switch(neg_value, SecretKey::new(&secp, &mut thread_rng()))
+            .blind_switch(neg_value, SecretKey::new(&mut thread_rng()))
             .unwrap();
 
         // now construct blinding factor to net out appropriately
@@ -1304,7 +1304,7 @@ mod tests {
     // provide an api to extract a public key from a commitment
     fn test_to_pubkey() {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let commit = secp.commit(5, blinding.clone()).unwrap();
         let pubkey = commit.to_pubkey(&secp);
         assert!(pubkey.is_ok());
@@ -1319,7 +1319,7 @@ mod tests {
     #[test]
     fn test_sign_with_pubkey_from_commitment() {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let commit = secp.commit(0u64, blinding.clone()).unwrap();
 
         let mut msg = [0u8; 32];
@@ -1354,8 +1354,8 @@ mod tests {
             secp.commit(value, blinding).unwrap()
         }
 
-        let blind_a = SecretKey::new(&secp, &mut thread_rng());
-        let blind_b = SecretKey::new(&secp, &mut thread_rng());
+        let blind_a = SecretKey::new(&mut thread_rng());
+        let blind_b = SecretKey::new(&mut thread_rng());
 
         let commit_a = commit(3, blind_a.clone());
         let commit_b = commit(2, blind_b.clone());
@@ -1411,19 +1411,19 @@ mod tests {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
         let rng = &mut thread_rng();
         let value: u64 = 1;
-        let blind = SecretKey::new(&secp, rng);
+        let blind = SecretKey::new(rng);
         let blind2 = ONE_KEY;
         assert_eq!(
             secp.commit(value, blind.clone()).unwrap(),
             secp.commit_blind(blind2.clone(), blind.clone()).unwrap()
         );
         let value: u64 = 2;
-        let blind = SecretKey::new(&secp, rng);
+        let blind = SecretKey::new(rng);
         assert_ne!(
             secp.commit(value, blind.clone()).unwrap(),
             secp.commit_blind(blind2, blind.clone()).unwrap()
         );
-        let blind = SecretKey::new(&secp, rng);
+        let blind = SecretKey::new(rng);
         let mut blind2 = ZERO_KEY;
         blind2.0[30] = rng.gen::<u8>();
         blind2.0[31] = rng.gen::<u8>();
@@ -1438,7 +1438,7 @@ mod tests {
     fn test_bullet_proof_single() {
         // Test Bulletproofs without message
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let value = 12345678;
         let commit = secp.commit(value, blinding.clone()).unwrap();
         let bullet_proof = secp.bullet_proof(
@@ -1478,7 +1478,7 @@ mod tests {
         // wrong blinding
         let value = 12345678;
         let commit = secp.commit(value, blinding).unwrap();
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let bullet_proof = secp.bullet_proof(
             value,
             blinding.clone(),
@@ -1496,7 +1496,7 @@ mod tests {
 
         // Commit to some extra data in the bulletproof
         let extra_data = [0u8; 32].to_vec();
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let value = 12345678;
         let commit = secp.commit(value, blinding.clone()).unwrap();
         let bullet_proof = secp.bullet_proof(
@@ -1527,9 +1527,9 @@ mod tests {
 
         // Ensure rewinding works
 
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
-        let rewind_nonce = SecretKey::new(&secp, &mut thread_rng());
-        let private_nonce = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
+        let rewind_nonce = SecretKey::new(&mut thread_rng());
+        let private_nonce = SecretKey::new(&mut thread_rng());
         let value = 12345678;
         let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1625,8 +1625,8 @@ mod tests {
 
             let common_nonce = nonce;
 
-            let private_nonce_a = SecretKey::new(&secp, &mut thread_rng());
-            let private_nonce_b = SecretKey::new(&secp, &mut thread_rng());
+            let private_nonce_a = SecretKey::new(&mut thread_rng());
+            let private_nonce_b = SecretKey::new(&mut thread_rng());
 
             // 1st step on party A: generate t_one and t_two, and sends to party B
             let mut t_one_a = PublicKey::new();
@@ -1666,15 +1666,15 @@ mod tests {
             let mut pubkeys = vec![];
             pubkeys.push(&t_one_a);
             pubkeys.push(&t_one_b);
-            let mut t_one_sum = PublicKey::from_combination(&secp, pubkeys.clone()).unwrap();
+            let mut t_one_sum = PublicKey::from_combination(pubkeys.clone()).unwrap();
 
             pubkeys.clear();
             pubkeys.push(&t_two_a);
             pubkeys.push(&t_two_b);
-            let mut t_two_sum = PublicKey::from_combination(&secp, pubkeys.clone()).unwrap();
+            let mut t_two_sum = PublicKey::from_combination(pubkeys.clone()).unwrap();
 
             // 2nd step on party A: use t_one_sum and t_two_sum to generate tau_x, and sent to party B.
-            let mut tau_x_a = SecretKey::new(&secp, &mut thread_rng());
+            let mut tau_x_a = SecretKey::new(&mut thread_rng());
             secp.bullet_proof_multisig(
                 value,
                 blinding_a.clone(),
@@ -1690,7 +1690,7 @@ mod tests {
             );
 
             // 2nd step on party B: use t_one_sum and t_two_sum to generate tau_x, and send to party A.
-            let mut tau_x_b = SecretKey::new(&secp, &mut thread_rng());
+            let mut tau_x_b = SecretKey::new(&mut thread_rng());
             secp.bullet_proof_multisig(
                 value,
                 blinding_b.clone(),
@@ -1707,7 +1707,7 @@ mod tests {
 
             // 2nd step on both party A and B: sum up both tau_x
             let mut tau_x_sum = tau_x_a;
-            tau_x_sum.add_assign(&secp, &tau_x_b).unwrap();
+            tau_x_sum.add_assign(&tau_x_b).unwrap();
 
             // 3rd step: party A finalizes bulletproof with input tau_x, t_one, t_two.
             let bullet_proof = secp
@@ -1736,12 +1736,12 @@ mod tests {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
         let value: u64 = 12345678;
 
-        let common_nonce = SecretKey::new(&secp, &mut thread_rng());
+        let common_nonce = SecretKey::new(&mut thread_rng());
 
-        let blinding_a = SecretKey::new(&secp, &mut thread_rng());
+        let blinding_a = SecretKey::new(&mut thread_rng());
         let partial_commit_a = secp.commit(value, blinding_a.clone()).unwrap();
 
-        let blinding_b = SecretKey::new(&secp, &mut thread_rng());
+        let blinding_b = SecretKey::new(&mut thread_rng());
         let partial_commit_b = secp.commit(0, blinding_b.clone()).unwrap();
 
         // 1. Test Bulletproofs multisig without message
@@ -1774,7 +1774,7 @@ mod tests {
         }
 
         // 3. wrong blinding
-        let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+        let wrong_blinding = SecretKey::new(&mut thread_rng());
         let (_, proof_range) = multisig_bp(
             value,
             common_nonce.clone(),
@@ -1886,8 +1886,8 @@ mod tests {
     #[test]
     fn rewind_empty_message() {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
-        let nonce = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
+        let nonce = SecretKey::new(&mut thread_rng());
         let value = <u64>::max_value() - 1;
         let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1913,8 +1913,8 @@ mod tests {
     #[test]
     fn rewind_message() {
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
-        let nonce = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
+        let nonce = SecretKey::new(&mut thread_rng());
         let value = <u64>::max_value() - 1;
         let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1934,7 +1934,7 @@ mod tests {
         assert_eq!(blinding, proof_info.blinding);
 
         // Using a different private nonce should prevent rewind of blinding factor
-        let private_nonce = SecretKey::new(&secp, &mut thread_rng());
+        let private_nonce = SecretKey::new(&mut thread_rng());
         let bullet_proof = secp.bullet_proof(
             value,
             blinding.clone(),
@@ -1956,7 +1956,7 @@ mod tests {
         let nano_to_millis = 1.0 / 1_000_000.0;
 
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
         let value = 12345678;
 
         let increments = vec![1, 2, 5, 10, 100, 200];
@@ -2003,10 +2003,10 @@ mod tests {
         let mut proofs: Vec<RangeProof> = vec![];
 
         let secp = Secp256k1::with_caps(ContextFlag::Commit);
-        let blinding = SecretKey::new(&secp, &mut thread_rng());
-        let rewind_nonce = SecretKey::new(&secp, &mut thread_rng());
-        let private_nonce = SecretKey::new(&secp, &mut thread_rng());
-        let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+        let blinding = SecretKey::new(&mut thread_rng());
+        let rewind_nonce = SecretKey::new(&mut thread_rng());
+        let private_nonce = SecretKey::new(&mut thread_rng());
+        let wrong_blinding = SecretKey::new(&mut thread_rng());
         let value = 12345678;
 
         let wrong_commit = secp.commit(value, wrong_blinding).unwrap();

--- a/src/secp_ser.rs
+++ b/src/secp_ser.rs
@@ -178,8 +178,7 @@ pub mod seckey_serde {
         String::deserialize(deserializer)
             .and_then(|string| hex::decode(string).map_err(|err| Error::custom(err.to_string())))
             .and_then(|bytes: Vec<u8>| {
-                SecretKey::from_slice(&bytes)
-                    .map_err(|err| Error::custom(err.to_string()))
+                SecretKey::from_slice(&bytes).map_err(|err| Error::custom(err.to_string()))
             })
     }
 }
@@ -206,8 +205,7 @@ pub mod pubkey_serde {
         String::deserialize(deserializer)
             .and_then(|string| hex::decode(string).map_err(|err| Error::custom(err.to_string())))
             .and_then(|bytes: Vec<u8>| {
-                PublicKey::from_slice(&bytes)
-                    .map_err(|err| Error::custom(err.to_string()))
+                PublicKey::from_slice(&bytes).map_err(|err| Error::custom(err.to_string()))
             })
     }
 }
@@ -234,8 +232,7 @@ pub mod pubkey_uncompressed_serde {
         String::deserialize(deserializer)
             .and_then(|string| hex::decode(string).map_err(|err| Error::custom(err.to_string())))
             .and_then(|bytes: Vec<u8>| {
-                PublicKey::from_slice(&bytes)
-                    .map_err(|err| Error::custom(err.to_string()))
+                PublicKey::from_slice(&bytes).map_err(|err| Error::custom(err.to_string()))
             })
     }
 }
@@ -251,9 +248,7 @@ pub mod option_sig_serde {
         S: Serializer,
     {
         match sig {
-            Some(sig) => {
-                serializer.serialize_str(&hex::encode(sig.serialize_compact().to_vec()))
-            }
+            Some(sig) => serializer.serialize_str(&hex::encode(sig.serialize_compact().to_vec())),
             None => serializer.serialize_none(),
         }
     }
@@ -301,8 +296,7 @@ pub mod sig_serde {
             .and_then(|bytes: Vec<u8>| {
                 let mut b = [0u8; 64];
                 b.copy_from_slice(&bytes[0..64]);
-                crate::Signature::from_compact(&b)
-                    .map_err(|err| Error::custom(err.to_string()))
+                crate::Signature::from_compact(&b).map_err(|err| Error::custom(err.to_string()))
             })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,7 +99,11 @@ impl Signature {
         }
 
         unsafe {
-            if ffi::secp256k1_ecdsa_signature_parse_compact(ffi::secp256k1_context_no_precomp, &mut ret, data.as_ptr()) == 1
+            if ffi::secp256k1_ecdsa_signature_parse_compact(
+                ffi::secp256k1_context_no_precomp,
+                &mut ret,
+                data.as_ptr(),
+            ) == 1
             {
                 Ok(Signature(ret))
             } else {
@@ -155,7 +159,11 @@ impl Signature {
         unsafe {
             // Ignore return value, which indicates whether the sig
             // was already normalized. We don't care.
-            ffi::secp256k1_ecdsa_signature_normalize(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), self.as_ptr());
+            ffi::secp256k1_ecdsa_signature_normalize(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_ptr(),
+                self.as_ptr(),
+            );
         }
     }
 
@@ -246,10 +254,7 @@ impl RecoverableSignature {
     /// Converts a compact-encoded byte slice to a signature. This
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
-    pub fn from_compact(
-        data: &[u8],
-        recid: RecoveryId,
-    ) -> Result<RecoverableSignature, Error> {
+    pub fn from_compact(data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
         let mut ret = unsafe { ffi::RecoverableSignature::blank() };
 
         unsafe {

--- a/src/types.rs
+++ b/src/types.rs
@@ -73,12 +73,12 @@ impl RecoveryId {
 impl Signature {
     #[inline]
     /// Converts a DER-encoded byte slice to a signature
-    pub fn from_der(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
+    pub fn from_der(data: &[u8]) -> Result<Signature, Error> {
         let mut ret = unsafe { ffi::Signature::blank() };
 
         unsafe {
             if ffi::secp256k1_ecdsa_signature_parse_der(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_ptr(),
                 data.len() as libc::size_t,
@@ -92,14 +92,14 @@ impl Signature {
     }
 
     /// Converts a 64-byte compact-encoded byte slice to a signature
-    pub fn from_compact(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
+    pub fn from_compact(data: &[u8]) -> Result<Signature, Error> {
         let mut ret = unsafe { ffi::Signature::blank() };
         if data.len() != 64 {
             return Err(Error::InvalidSignature);
         }
 
         unsafe {
-            if ffi::secp256k1_ecdsa_signature_parse_compact(secp.ctx, &mut ret, data.as_ptr()) == 1
+            if ffi::secp256k1_ecdsa_signature_parse_compact(ffi::secp256k1_context_no_precomp, &mut ret, data.as_ptr()) == 1
             {
                 Ok(Signature(ret))
             } else {
@@ -117,11 +117,11 @@ impl Signature {
     /// only useful for validating signatures in the Bitcoin blockchain from before
     /// 2016. It should never be used in new applications. This library does not
     /// support serializing to this "format"
-    pub fn from_der_lax(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
+    pub fn from_der_lax(data: &[u8]) -> Result<Signature, Error> {
         unsafe {
             let mut ret = ffi::Signature::blank();
             if ffi::ecdsa_signature_parse_der_lax(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_ptr(),
                 data.len() as libc::size_t,
@@ -151,11 +151,11 @@ impl Signature {
     /// valid. (For example, parsing the historic Bitcoin blockchain requires
     /// this.) For these applications we provide this normalization function,
     /// which ensures that the s value lies in the lower half of its range.
-    pub fn normalize_s(&mut self, secp: &Secp256k1) {
+    pub fn normalize_s(&mut self) {
         unsafe {
             // Ignore return value, which indicates whether the sig
             // was already normalized. We don't care.
-            ffi::secp256k1_ecdsa_signature_normalize(secp.ctx, self.as_mut_ptr(), self.as_ptr());
+            ffi::secp256k1_ecdsa_signature_normalize(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), self.as_ptr());
         }
     }
 
@@ -173,12 +173,12 @@ impl Signature {
 
     #[inline]
     /// Serializes the signature in DER format
-    pub fn serialize_der(&self, secp: &Secp256k1) -> Vec<u8> {
+    pub fn serialize_der(&self) -> Vec<u8> {
         let mut ret = Vec::with_capacity(72);
         let mut len: size_t = ret.capacity() as size_t;
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_der(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 ret.as_mut_ptr(),
                 &mut len,
                 self.as_ptr(),
@@ -191,11 +191,11 @@ impl Signature {
 
     #[inline]
     /// Serializes the signature in compact format
-    pub fn serialize_compact(&self, secp: &Secp256k1) -> [u8; 64] {
+    pub fn serialize_compact(&self) -> [u8; 64] {
         let mut ret = [0; 64];
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_compact(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 ret.as_mut_ptr(),
                 self.as_ptr(),
             );
@@ -247,7 +247,6 @@ impl RecoverableSignature {
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(
-        secp: &Secp256k1,
         data: &[u8],
         recid: RecoveryId,
     ) -> Result<RecoverableSignature, Error> {
@@ -257,7 +256,7 @@ impl RecoverableSignature {
             if data.len() != 64 {
                 Err(Error::InvalidSignature)
             } else if ffi::secp256k1_ecdsa_recoverable_signature_parse_compact(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_ptr(),
                 recid.0,
@@ -278,12 +277,12 @@ impl RecoverableSignature {
 
     #[inline]
     /// Serializes the recoverable signature in compact format
-    pub fn serialize_compact(&self, secp: &Secp256k1) -> (RecoveryId, [u8; 64]) {
+    pub fn serialize_compact(&self) -> (RecoveryId, [u8; 64]) {
         let mut ret = [0u8; 64];
         let mut recid = 0i32;
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_serialize_compact(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 ret.as_mut_ptr(),
                 &mut recid,
                 self.as_ptr(),
@@ -296,11 +295,11 @@ impl RecoverableSignature {
     /// Converts a recoverable signature to a non-recoverable one (this is needed
     /// for verification
     #[inline]
-    pub fn to_standard(&self, secp: &Secp256k1) -> Signature {
+    pub fn to_standard(&self) -> Signature {
         let mut ret = unsafe { ffi::Signature::blank() };
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_convert(
-                secp.ctx,
+                ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 self.as_ptr(),
             );
@@ -421,7 +420,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 
@@ -561,7 +560,7 @@ impl Secp256k1 {
         &self,
         rng: &mut R,
     ) -> Result<(key::SecretKey, key::PublicKey), Error> {
-        let sk = key::SecretKey::new(self, rng);
+        let sk = key::SecretKey::new(rng);
         let pk = key::PublicKey::from_secret_key(self, &sk)?;
         Ok((sk, pk))
     }
@@ -736,9 +735,9 @@ mod tests {
         assert_eq!(full.recover(&msg, &sigr), Ok(pk));
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize_vec(&none, true), &sk[..]);
-        let new_pk = PublicKey::from_slice(&none, pk_slice).unwrap();
-        let new_sk = SecretKey::from_slice(&none, sk_slice).unwrap();
+        let (pk_slice, sk_slice) = (&pk.serialize_vec(true), &sk[..]);
+        let new_pk = PublicKey::from_slice(pk_slice).unwrap();
+        let new_sk = SecretKey::from_slice(sk_slice).unwrap();
         assert_eq!(sk, new_sk);
         assert_eq!(pk, new_pk);
     }
@@ -752,14 +751,14 @@ mod tests {
     #[test]
     fn invalid_pubkey() {
         let s = Secp256k1::new();
-        let sig = RecoverableSignature::from_compact(&s, &[1; 64], RecoveryId(0)).unwrap();
+        let sig = RecoverableSignature::from_compact(&[1; 64], RecoveryId(0)).unwrap();
         let pk = PublicKey::new();
         let mut msg = [0u8; 32];
         thread_rng().fill(&mut msg);
         let msg = Message::from_slice(&msg).unwrap();
 
         assert_eq!(
-            s.verify(&msg, &sig.to_standard(&s), &pk),
+            s.verify(&msg, &sig.to_standard(), &pk),
             Err(InvalidPublicKey)
         );
     }
@@ -773,14 +772,13 @@ mod tests {
             0, 0, 1,
         ];
 
-        let sk = SecretKey::from_slice(&s, &one).unwrap();
+        let sk = SecretKey::from_slice(&one).unwrap();
         let msg = Message::from_slice(&one).unwrap();
 
         let sig = s.sign_recoverable(&msg, &sk).unwrap();
         assert_eq!(
             Ok(sig),
             RecoverableSignature::from_compact(
-                &s,
                 &[
                     0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f, 0x04, 0x77, 0x2b, 0x6f, 0x92,
                     0x1f, 0x0b, 0xa6, 0xaf, 0x0c, 0x1e, 0x77, 0xfc, 0x43, 0x9e, 0x65, 0xc3, 0x6d,
@@ -805,25 +803,25 @@ mod tests {
 
             let (sk, _) = s.generate_keypair(&mut thread_rng()).unwrap();
             let sig1 = s.sign(&msg, &sk).unwrap();
-            let der = sig1.serialize_der(&s);
+            let der = sig1.serialize_der();
             println!(
                 "ecdsa signature len: {}, der: {}",
                 der.len(),
                 hex::encode(der.clone())
             );
-            let sig2 = Signature::from_der(&s, &der[..]).unwrap();
+            let sig2 = Signature::from_der(&der[..]).unwrap();
             assert_eq!(sig1, sig2);
 
-            let compact = sig1.serialize_compact(&s);
-            let sig2 = Signature::from_compact(&s, &compact[..]).unwrap();
+            let compact = sig1.serialize_compact();
+            let sig2 = Signature::from_compact(&compact[..]).unwrap();
             assert_eq!(sig1, sig2);
 
             round_trip_serde!(sig1);
 
-            assert!(Signature::from_compact(&s, &der[..]).is_err());
-            assert!(Signature::from_compact(&s, &compact[0..4]).is_err());
-            assert!(Signature::from_der(&s, &compact[..]).is_err());
-            assert!(Signature::from_der(&s, &der[0..4]).is_err());
+            assert!(Signature::from_compact(&der[..]).is_err());
+            assert!(Signature::from_compact(&compact[0..4]).is_err());
+            assert!(Signature::from_der(&compact[..]).is_err());
+            assert!(Signature::from_der(&der[0..4]).is_err());
         }
     }
 
@@ -831,9 +829,8 @@ mod tests {
     fn signature_lax_der() {
         macro_rules! check_lax_sig(
             ($hex:expr) => ({
-                let secp = Secp256k1::without_caps();
                 let sig = hex!($hex);
-                assert!(Signature::from_der_lax(&secp, &sig[..]).is_ok());
+                assert!(Signature::from_der_lax(&sig[..]).is_ok());
             })
         );
 
@@ -885,7 +882,7 @@ mod tests {
 
         for key in wild_keys
             .iter()
-            .map(|k| SecretKey::from_slice(&s, &k[..]).unwrap())
+            .map(|k| SecretKey::from_slice(&k[..]).unwrap())
         {
             for msg in wild_msgs
                 .iter()
@@ -910,7 +907,7 @@ mod tests {
         let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
 
         let sigr = s.sign_recoverable(&msg, &sk).unwrap();
-        let sig = sigr.to_standard(&s);
+        let sig = sigr.to_standard();
 
         let mut msg = [0u8; 32];
         thread_rng().fill(&mut msg);
@@ -945,22 +942,21 @@ mod tests {
         let msg = Message::from_slice(&[0x55; 32]).unwrap();
 
         // Zero is not a valid sig
-        let sig = RecoverableSignature::from_compact(&s, &[0; 64], RecoveryId(0)).unwrap();
+        let sig = RecoverableSignature::from_compact(&[0; 64], RecoveryId(0)).unwrap();
         assert_eq!(s.recover(&msg, &sig), Err(InvalidSignature));
         // ...but 111..111 is
-        let sig = RecoverableSignature::from_compact(&s, &[1; 64], RecoveryId(0)).unwrap();
+        let sig = RecoverableSignature::from_compact(&[1; 64], RecoveryId(0)).unwrap();
         assert!(s.recover(&msg, &sig).is_ok());
     }
 
     #[test]
     fn test_bad_slice() {
-        let s = Secp256k1::new();
         assert_eq!(
-            Signature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE + 1]),
+            Signature::from_der(&[0; constants::MAX_SIGNATURE_SIZE + 1]),
             Err(InvalidSignature)
         );
         assert_eq!(
-            Signature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE]),
+            Signature::from_der(&[0; constants::MAX_SIGNATURE_SIZE]),
             Err(InvalidSignature)
         );
 
@@ -977,9 +973,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let s = Secp256k1::new();
         let sig = RecoverableSignature::from_compact(
-            &s,
             &[
                 0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f, 0x04, 0x77, 0x2b, 0x6f, 0x92, 0x1f,
                 0x0b, 0xa6, 0xaf, 0x0c, 0x1e, 0x77, 0xfc, 0x43, 0x9e, 0x65, 0xc3, 0x6d, 0xed, 0xf4,
@@ -1004,8 +998,6 @@ mod tests {
 
     #[test]
     fn test_recov_sig_serialize_compact() {
-        let s = Secp256k1::new();
-
         let recid_in = RecoveryId(1);
         let bytes_in = &[
             0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f, 0x04, 0x77, 0x2b, 0x6f, 0x92, 0x1f,
@@ -1014,8 +1006,8 @@ mod tests {
             0x0e, 0xf8, 0x02, 0x5e, 0x70, 0x9f, 0xff, 0x20, 0x80, 0xc4, 0xa3, 0x9a, 0xae, 0x06,
             0x8d, 0x12, 0xee, 0xd0, 0x09, 0xb6, 0x8c, 0x89,
         ];
-        let sig = RecoverableSignature::from_compact(&s, bytes_in, recid_in).unwrap();
-        let (recid_out, bytes_out) = sig.serialize_compact(&s);
+        let sig = RecoverableSignature::from_compact(bytes_in, recid_in).unwrap();
+        let (recid_out, bytes_out) = sig.serialize_compact();
         assert_eq!(recid_in, recid_out);
         assert_eq!(&bytes_in[..], &bytes_out[..]);
     }
@@ -1044,14 +1036,14 @@ mod tests {
         let msg = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");
 
         let secp = Secp256k1::new();
-        let mut sig = Signature::from_der(&secp, &sig[..]).unwrap();
-        let pk = PublicKey::from_slice(&secp, &pk[..]).unwrap();
+        let mut sig = Signature::from_der(&sig[..]).unwrap();
+        let pk = PublicKey::from_slice(&pk[..]).unwrap();
         let msg = Message::from_slice(&msg[..]).unwrap();
 
         // without normalization we expect this will fail
         assert_eq!(secp.verify(&msg, &sig, &pk), Err(IncorrectSignature));
         // after normalization it should pass
-        sig.normalize_s(&secp);
+        sig.normalize_s();
         assert_eq!(secp.verify(&msg, &sig, &pk), Ok(()));
     }
 }


### PR DESCRIPTION
This is the corresponding PR for https://github.com/gottstech/secp256k1-zkp/pull/5.

For type serialization/parsing functions, they do not require expensive precomputations or dynamic
allocations, so a `simple secp256k1 context object` is desiged for that and no explicit context is needed.

This will give a lot of simplification on those serialization/parsing functions, especially getting an big improvement to avoid the secp mutex locking just for serialization/deser.

