### PR TITLE
improvement: commit api don't need the SecretKey move

### DIFF
--- a/src/secp_ser.rs
+++ b/src/secp_ser.rs
@@ -387,10 +387,10 @@ mod test {
                 seckey2: sk.clone(),
                 pubkey2: PublicKey::from_secret_key(&secp, &sk).unwrap(),
                 sig2: sig.clone(),
-                commit2: secp.commit(100u64, sk.clone()).unwrap(),
+                commit2: secp.commit(100u64, &sk).unwrap(),
                 commit_vec2: vec![
-                    secp.commit(200u64, sk.clone()).unwrap(),
-                    secp.commit(300u64, sk.clone()).unwrap(),
+                    secp.commit(200u64, &sk).unwrap(),
+                    secp.commit(300u64, &sk).unwrap(),
                 ],
                 pubkey3: PublicKey::from_secret_key(&secp, &sk).unwrap(),
             }


### PR DESCRIPTION
Before this PR, the `commit` api need a `SecretKey` move:
```Rust
pub fn commit(&self, value: u64, blind: SecretKey) -> Result<Commitment, Error>
```

After this PR, it only need a reference and avoid the move:
```Rust
pub fn commit(&self, value: u64, blind: &SecretKey) -> Result<Commitment, Error> 
```

This will remove a lot of `clone` for the `SecretKey`, and release some headache.
