### PR TITLE
Improvement: add 'to_string' and 'from_str' for most of common types

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Grin Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rustfmt --version &>/dev/null
+if [ $? != 0 ]; then
+	printf "[pre_commit] \033[0;31merror\033[0m: \"rustfmt\" not available. \n"
+	printf "[pre_commit] \033[0;31merror\033[0m: rustfmt can be installed via - \n"
+	printf "[pre_commit] $ rustup component add rustfmt-preview \n"
+	exit 1
+fi
+
+result=0
+problem_files=()
+
+printf "[pre_commit] rustfmt "
+
+for file in $(git diff --name-only --cached); do
+	if [ ${file: -3} == ".rs" ]; then
+		# first collect all the files that need reformatting
+		rustfmt --check $file &>/dev/null
+		if [ $? != 0 ]; then
+			problem_files+=($file)
+			result=1
+		fi
+	fi
+done
+
+# now reformat all the files that need reformatting
+for file in ${problem_files[@]}; do
+	rustfmt $file
+done
+
+# and let the user know what just happened (and which files were affected)
+printf "\033[0;32mok\033[0m \n"
+if [ $result != 0 ]; then
+	# printf "\033[0;31mrustfmt\033[0m \n"
+	printf "[pre_commit] the following files were rustfmt'd (not yet committed): \n"
+
+	for file in ${problem_files[@]}; do
+		printf "\033[0;31m    $file\033[0m \n"
+	done
+fi
+
+exit 0
+# to actually fail the build on rustfmt failure -
+# exit $result

--- a/build.rs
+++ b/build.rs
@@ -44,29 +44,31 @@ fn main() {
     }
 
     let mut base_config = cc::Build::new();
-    base_config.include("depend/secp256k1-zkp/")
-               .include("depend/secp256k1-zkp/include")
-               .include("depend/secp256k1-zkp/src")
-               .flag("-g")
-               // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
-               .define("USE_NUM_NONE", Some("1"))
-               .define("USE_FIELD_INV_BUILTIN", Some("1"))
-               .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               // TODO these should use 64-bit variants on 64-bit systems
-               .define("USE_FIELD_10X26", Some("1"))
-               .define("USE_SCALAR_8X32", Some("1"))
-               .define("USE_ENDOMORPHISM", Some("1"))
-               // These all are OK.
-               .define("ENABLE_MODULE_ECDH", Some("1"))
-               .define("ENABLE_MODULE_GENERATOR", Some("1"))
-               .define("ENABLE_MODULE_RECOVERY", Some("1"))
-               .define("ENABLE_MODULE_RANGEPROOF", Some("1"))
-               .define("ENABLE_MODULE_BULLETPROOF", Some("1"))
-               .define("ENABLE_MODULE_AGGSIG", Some("1"))
-               .define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
+    base_config
+        .include("depend/secp256k1-zkp/")
+        .include("depend/secp256k1-zkp/include")
+        .include("depend/secp256k1-zkp/src")
+        .flag("-g")
+        // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
+        .define("USE_NUM_NONE", Some("1"))
+        .define("USE_FIELD_INV_BUILTIN", Some("1"))
+        .define("USE_SCALAR_INV_BUILTIN", Some("1"))
+        // TODO these should use 64-bit variants on 64-bit systems
+        .define("USE_FIELD_10X26", Some("1"))
+        .define("USE_SCALAR_8X32", Some("1"))
+        .define("USE_ENDOMORPHISM", Some("1"))
+        // These all are OK.
+        .define("ENABLE_MODULE_ECDH", Some("1"))
+        .define("ENABLE_MODULE_GENERATOR", Some("1"))
+        .define("ENABLE_MODULE_RECOVERY", Some("1"))
+        .define("ENABLE_MODULE_RANGEPROOF", Some("1"))
+        .define("ENABLE_MODULE_BULLETPROOF", Some("1"))
+        .define("ENABLE_MODULE_AGGSIG", Some("1"))
+        .define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
 
     // secp256k1-zkp
-    base_config.file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")
-               .file("depend/secp256k1-zkp/src/secp256k1.c")
-               .compile("libsecp256k1.a");
+    base_config
+        .file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")
+        .file("depend/secp256k1-zkp/src/secp256k1.c")
+        .compile("libsecp256k1.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,28 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use std::path::PathBuf;
+use std::process::Command;
+
 fn main() {
+    // Setting up git hooks in the project: rustfmt and so on.
+    let git_hooks = format!(
+        "git config core.hooksPath {}",
+        PathBuf::from("./.hooks").to_str().unwrap()
+    );
+
+    if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .args(&["/C", &git_hooks])
+            .output()
+            .expect("failed to execute git config for hooks");
+    } else {
+        Command::new("sh")
+            .args(&["-c", &git_hooks])
+            .output()
+            .expect("failed to execute git config for hooks");
+    }
+
     let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1-zkp/")
                .include("depend/secp256k1-zkp/include")

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -397,13 +397,13 @@ mod tests {
     };
     use crate::ffi;
     use crate::key::{PublicKey, SecretKey};
+    use crate::secp_ser;
     use crate::ContextFlag;
     use crate::{AggSigPartialSignature, Message, Signature};
-    use crate::secp_ser;
 
+    use rand::{thread_rng, Rng};
     use serde::{self, Deserialize, Serialize};
     use serde_json;
-    use rand::{thread_rng, Rng};
 
     #[test]
     fn test_aggsig_multisig() {
@@ -562,7 +562,10 @@ mod tests {
             msg,
             sig,
         };
-        println!("format with serde mod: {}", serde_json::to_string_pretty(&struct_test).unwrap());
+        println!(
+            "format with serde mod: {}",
+            serde_json::to_string_pretty(&struct_test).unwrap()
+        );
     }
 
     #[test]

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -399,6 +399,10 @@ mod tests {
     use crate::key::{PublicKey, SecretKey};
     use crate::ContextFlag;
     use crate::{AggSigPartialSignature, Message, Signature};
+    use crate::secp_ser;
+
+    use serde::{self, Deserialize, Serialize};
+    use serde_json;
     use rand::{thread_rng, Rng};
 
     #[test]
@@ -509,6 +513,56 @@ mod tests {
         let sig = sign_single(&secp, &msg, &sk, None, Some(&sk_extra), None, None, None).unwrap();
         let result = verify_single(&secp, &sig, &msg, None, &pk, None, Some(&pk_extra), false);
         assert!(result == true);
+    }
+
+    #[test]
+    fn test_aggsig_serialize() {
+        let secp = Secp256k1::with_caps(ContextFlag::Full);
+        for _ in 0..50 {
+            let (sk, _pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+            let mut msg = [0u8; 32];
+            thread_rng().fill(&mut msg);
+            let msg = Message::from_slice(&msg).unwrap();
+            let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
+
+            assert_eq!(sig, Signature::from_str(&sig.to_string()).unwrap());
+        }
+
+        // more tests on one example
+        let (sk, pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+        let mut msg = [0u8; 32];
+        thread_rng().fill(&mut msg);
+        let msg = Message::from_slice(&msg).unwrap();
+        let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
+        println!("secret key: \t{}", sk.to_string());
+        println!("public key: \t{}", pk.to_string());
+        println!("message: \t{}", msg.to_string());
+        println!("signature: \t{}", sig.to_string());
+        println!("sig raw: \t{:?}", sig);
+
+        // round-trips
+        assert_eq!(sk, SecretKey::from_str(&sk.to_string()).unwrap());
+        assert_eq!(pk, PublicKey::from_str(&pk.to_string()).unwrap());
+        assert_eq!(msg, Message::from_str(&msg.to_string()).unwrap());
+        assert_eq!(sig, Signature::from_str(&sig.to_string()).unwrap());
+
+        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+        struct SerTest {
+            pub sec_key: SecretKey,
+            #[serde(with = "secp_ser::pubkey_serde")]
+            pub pub_key: PublicKey,
+            pub msg: Message,
+            #[serde(with = "secp_ser::sig_serde")]
+            pub sig: Signature,
+        }
+
+        let struct_test = SerTest {
+            sec_key: sk,
+            pub_key: pk,
+            msg,
+            sig,
+        };
+        println!("format with serde mod: {}", serde_json::to_string_pretty(&struct_test).unwrap());
     }
 
     #[test]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -96,7 +96,7 @@ impl PublicKey {
     }
     /// Create a new (uninitialized) public key usable for the FFI interface
     pub unsafe fn blank() -> PublicKey {
-        mem::uninitialized()
+        mem::MaybeUninit::<PublicKey>::uninit().assume_init()
     }
 }
 
@@ -141,7 +141,7 @@ impl Signature {
     }
     /// Create a new (uninitialized) signature usable for the FFI interface
     pub unsafe fn blank() -> Signature {
-        mem::uninitialized()
+        mem::MaybeUninit::<Signature>::uninit().assume_init()
     }
 }
 
@@ -152,7 +152,7 @@ impl RecoverableSignature {
     }
     /// Create a new (uninitialized) signature usable for the FFI interface
     pub unsafe fn blank() -> RecoverableSignature {
-        mem::uninitialized()
+        mem::MaybeUninit::<RecoverableSignature>::uninit().assume_init()
     }
 }
 
@@ -163,7 +163,7 @@ impl AggSigPartialSignature {
     }
     /// Create a new (uninitialized) signature usable for the FFI interface
     pub unsafe fn blank() -> AggSigPartialSignature {
-        mem::uninitialized()
+        mem::MaybeUninit::<AggSigPartialSignature>::uninit().assume_init()
     }
 }
 
@@ -180,7 +180,7 @@ impl SharedSecret {
     }
     /// Create a new (uninitialized) signature usable for the FFI interface
     pub unsafe fn blank() -> SharedSecret {
-        mem::uninitialized()
+        mem::MaybeUninit::<SharedSecret>::uninit().assume_init()
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -427,7 +427,10 @@ mod test {
 
         // round-trip test
         let pubkey_str = uncompressed.unwrap().to_string();
-        assert_eq!(pubkey_str, PublicKey::from_str(&pubkey_str).unwrap().to_string());
+        assert_eq!(
+            pubkey_str,
+            PublicKey::from_str(&pubkey_str).unwrap().to_string()
+        );
 
         let compressed = PublicKey::from_slice(&[
             3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41,
@@ -437,7 +440,10 @@ mod test {
 
         // round-trip test
         let pubkey_str = compressed.unwrap().to_string();
-        assert_eq!(pubkey_str, PublicKey::from_str(&pubkey_str).unwrap().to_string());
+        assert_eq!(
+            pubkey_str,
+            PublicKey::from_str(&pubkey_str).unwrap().to_string()
+        );
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -157,6 +157,17 @@ impl SecretKey {
             }
         }
     }
+
+    /// Get the SecretKey hex string
+    pub fn to_string(&self) -> String {
+        hex::encode(self.as_ref())
+    }
+
+    /// Build a SecretKey from a hex string
+    pub fn from_str(s: &str) -> Result<SecretKey, Error> {
+        let raw = hex::decode(s).map_err(|_| Error::InvalidSecretKey)?;
+        SecretKey::from_slice(&raw)
+    }
 }
 
 impl PublicKey {
@@ -307,6 +318,21 @@ impl PublicKey {
             }
         }
     }
+
+    /// Get the PublicKey hex string
+    pub fn to_string(&self) -> String {
+        hex::encode(self.serialize_vec(true))
+    }
+
+    /// Build a PublicKey from a hex string
+    pub fn from_str(s: &str) -> Result<PublicKey, Error> {
+        let raw = hex::decode(s).map_err(|_| Error::InvalidPublicKey)?;
+        if raw.len() == constants::COMPRESSED_PUBLIC_KEY_SIZE {
+            PublicKey::from_slice(&raw)
+        } else {
+            Err(Error::InvalidPublicKey)
+        }
+    }
 }
 
 /// Creates a new public key from a FFI public key
@@ -331,6 +357,23 @@ mod test {
 
     use crate::key::ONE_KEY;
     use std::slice::from_raw_parts;
+
+    struct DumbRng(u32);
+    impl RngCore for DumbRng {
+        fn next_u32(&mut self) -> u32 {
+            self.0 = self.0.wrapping_add(1);
+            self.0
+        }
+        fn next_u64(&mut self) -> u64 {
+            self.next_u32() as u64
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            impls::fill_bytes_via_next(self, dest)
+        }
+        fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
+            unimplemented!()
+        }
+    }
 
     // This tests cleaning of SecretKey (e.g. secret key) on Drop.
     // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.
@@ -382,11 +425,19 @@ mod test {
         ]);
         assert!(uncompressed.is_ok());
 
+        // round-trip test
+        let pubkey_str = uncompressed.unwrap().to_string();
+        assert_eq!(pubkey_str, PublicKey::from_str(&pubkey_str).unwrap().to_string());
+
         let compressed = PublicKey::from_slice(&[
             3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41,
             111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78,
         ]);
         assert!(compressed.is_ok());
+
+        // round-trip test
+        let pubkey_str = compressed.unwrap().to_string();
+        assert_eq!(pubkey_str, PublicKey::from_str(&pubkey_str).unwrap().to_string());
     }
 
     #[test]
@@ -590,23 +641,6 @@ mod test {
 
     #[test]
     fn test_debug_output() {
-        struct DumbRng(u32);
-        impl RngCore for DumbRng {
-            fn next_u32(&mut self) -> u32 {
-                self.0 = self.0.wrapping_add(1);
-                self.0
-            }
-            fn next_u64(&mut self) -> u64 {
-                self.next_u32() as u64
-            }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
-                impls::fill_bytes_via_next(self, dest)
-            }
-            fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
-                unimplemented!()
-            }
-        }
-
         let s = Secp256k1::new();
         let (sk, _) = s.generate_keypair(&mut DumbRng(0)).unwrap();
 
@@ -618,23 +652,6 @@ mod test {
 
     #[test]
     fn test_pubkey_serialize() {
-        struct DumbRng(u32);
-        impl RngCore for DumbRng {
-            fn next_u32(&mut self) -> u32 {
-                self.0 = self.0.wrapping_add(1);
-                self.0
-            }
-            fn next_u64(&mut self) -> u64 {
-                self.next_u32() as u64
-            }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
-                impls::fill_bytes_via_next(self, dest)
-            }
-            fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
-                unimplemented!()
-            }
-        }
-
         let s = Secp256k1::new();
         let (_, pk1) = s.generate_keypair(&mut DumbRng(0)).unwrap();
         assert_eq!(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! impl_array_newtype {
                 unsafe {
                     use std::mem;
                     use std::ptr::copy_nonoverlapping;
-                    let mut ret: $thing = mem::uninitialized();
+                    let mut ret = mem::MaybeUninit::<$thing>::uninit().assume_init();
                     copy_nonoverlapping(self.as_ptr(), ret.as_mut_ptr(), mem::size_of::<$thing>());
                     ret
                 }

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -154,7 +154,8 @@ impl Clone for RangeProof {
     fn clone(&self) -> RangeProof {
         unsafe {
             use std::ptr::copy_nonoverlapping;
-            let mut ret: [u8; constants::MAX_PROOF_SIZE] = mem::MaybeUninit::<[u8; constants::MAX_PROOF_SIZE]>::uninit().assume_init();
+            let mut ret: [u8; constants::MAX_PROOF_SIZE] =
+                mem::MaybeUninit::<[u8; constants::MAX_PROOF_SIZE]>::uninit().assume_init();
             copy_nonoverlapping(
                 self.proof.as_ptr(),
                 ret.as_mut_ptr(),
@@ -666,7 +667,8 @@ impl Secp256k1 {
     ) -> ProofInfo {
         let mut value: u64 = 0;
         let mut blind = unsafe { mem::MaybeUninit::<[u8; 32]>::uninit().assume_init() };
-        let mut message = unsafe { mem::MaybeUninit::<[u8; constants::PROOF_MSG_SIZE]>::uninit().assume_init() };
+        let mut message =
+            unsafe { mem::MaybeUninit::<[u8; constants::PROOF_MSG_SIZE]>::uninit().assume_init() };
         let mut mlen: usize = constants::PROOF_MSG_SIZE;
         let mut min: u64 = 0;
         let mut max: u64 = 0;

--- a/src/types.rs
+++ b/src/types.rs
@@ -217,6 +217,21 @@ impl Signature {
     pub fn to_raw_data(&self) -> [u8; 64] {
         (self.0).0.clone()
     }
+
+    /// Get the Signature hex string
+    pub fn to_string(&self) -> String {
+        hex::encode(&self.serialize_compact()[..])
+    }
+
+    /// Build a Signature from a hex string
+    pub fn from_str(s: &str) -> Result<Signature, Error> {
+        let raw = hex::decode(s).map_err(|_| Error::InvalidSignature)?;
+        if raw.len() == constants::COMPACT_SIGNATURE_SIZE {
+            Signature::from_compact(&raw)
+        } else {
+            Err(Error::InvalidSignature)
+        }
+    }
 }
 
 /// Creates a new signature from a FFI signature
@@ -381,6 +396,17 @@ impl Message {
             _ => Err(Error::InvalidMessage),
         }
     }
+
+    /// Get the Message hex string
+    pub fn to_string(&self) -> String {
+        hex::encode(self.as_ref())
+    }
+
+    /// Build a Message from a hex string
+    pub fn from_str(s: &str) -> Result<Message, Error> {
+        let raw = hex::decode(s).map_err(|_| Error::InvalidMessage)?;
+        Message::from_slice(&raw)
+    }
 }
 
 /// Creates a message from a `MESSAGE_SIZE` byte array
@@ -415,6 +441,8 @@ pub enum Error {
     InvalidRangeProof,
     /// Error creating partial signature
     PartialSigFailure,
+    /// Bad commitment
+    InvalidCommitment,
 }
 
 // Passthrough Debug to Display, since errors should be user-visible
@@ -441,6 +469,7 @@ impl error::Error for Error {
             Error::IncorrectCommitSum => "secp: invalid pedersen commitment sum",
             Error::InvalidRangeProof => "secp: invalid range proof",
             Error::PartialSigFailure => "secp: partial sig (aggsig) failure",
+            Error::InvalidCommitment => "secp: invalid commitment",
         }
     }
 }


### PR DESCRIPTION
Some improvements:
- Fix a warning: use of deprecated item 'std::mem::uninitialized'
- Add 'to_string' and 'from_str' for Commitment, PublicKey, SecretKey, Signature, Message.
- Add option_seckey_serde for Option<SecretKey> Serialization/Deser.
- Add rustfmt into the git commit pre-hook.